### PR TITLE
Check for Integer instead of Fixnum/Bignum

### DIFF
--- a/lib/xmlrpc/create.rb
+++ b/lib/xmlrpc/create.rb
@@ -176,7 +176,7 @@ module XMLRPC # :nodoc:
     def conv2value(param) # :doc:
 
         val = case param
-        when Fixnum, Bignum
+        when Integer
           # XML-RPC's int is 32bit int, and Fixnum also may be beyond 32bit
           if Config::ENABLE_BIGINT
             @writer.tag("i4", param.to_s)


### PR DESCRIPTION
The latter two are deprecated in Ruby 2.4 and issue warnings. The
superclass Integer has been available for some releases now.