### PR TITLE
Remove hack to prevent years < 1970 in DateTime

### DIFF
--- a/lib/xmlrpc/datetime.rb
+++ b/lib/xmlrpc/datetime.rb
@@ -87,16 +87,10 @@ class DateTime
   end
 
   # Return a Time object of the date/time which represents +self+.
-  # If the <code>@year</code> is below 1970, this method returns +nil+,
-  # because Time cannot handle years below 1970.
   #
   # The timezone used is GMT.
   def to_time
-    if @year >= 1970
-      Time.gm(*to_a)
-    else
-      nil
-    end
+    Time.gm(*to_a)
   end
 
   # Return a Date object of the date which represents +self+.

--- a/test/test_datetime.rb
+++ b/test/test_datetime.rb
@@ -130,10 +130,18 @@ class Test_DateTime < Test::Unit::TestCase
   end
 
   def test_to_time2
-    dt = createDateTime()
-    dt.year = 1969
+    y, m, d, h, mi, s = 1969, 3, 24, 12, 0, 5
+    dt = XMLRPC::DateTime.new(y, m, d, h, mi, s)
+    time = dt.to_time
 
-    assert_nil(dt.to_time)
+    assert_not_nil(time)
+
+    assert_equal(y,  time.year)
+    assert_equal(m,  time.month)
+    assert_equal(d,  time.day)
+    assert_equal(h,  time.hour)
+    assert_equal(mi, time.min)
+    assert_equal(s,  time.sec)
   end
 
   def test_to_date1


### PR DESCRIPTION
Time can handle dates before epoch perfectly fine. The test here is
probably something from ancient times and breaks stuff these days
without reason.