### PR TITLE
Backport the gem to Ruby 2.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
+  - "2.3.0"
+  - "2.4.0"
   - ruby-head
 before_install: gem install bundler -v 1.11.2

--- a/test/webrick_testing.rb
+++ b/test/webrick_testing.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: false
 require 'timeout'
 
+# Backport of WEBrick::Utils::TimeoutHandler.terminate from Ruby 2.4.
+unless WEBrick::Utils::TimeoutHandler.respond_to? :terminate
+  class WEBrick::Utils::TimeoutHandler
+    def self.terminate
+      instance.terminate
+    end
+
+    def terminate
+      TimeoutMutex.synchronize{
+        @timeout_info.clear
+        @watcher&.kill&.join
+      }
+    end
+  end
+end
+
 module TestXMLRPC
 module WEBrick_Testing
   def teardown

--- a/xmlrpc.gemspec
+++ b/xmlrpc.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.4.0dev"
+  spec.required_ruby_version = ">= 2.3"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This makes it possible to start using the gem in a project that aims to migrate to Ruby 2.4, but must still work with 2.3 until the migration completes.

Thank you for your great work on Ruby!