### PR TITLE
Removed reference to MiniTest

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,7 +32,7 @@ module Test
           if message
             msg = "#{message}\n#{msg}"
           end
-          raise MiniTest::Assertion, msg
+          raise Test::Unit::AssertionFailedError, msg
         end
         values
       end


### PR DESCRIPTION
We use Test::Unit everywhere, keep it consistent