### PR TITLE
gemspec: Remove unused directive "executables"

### DIFF
--- a/xmlrpc.gemspec
+++ b/xmlrpc.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |spec|
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3"
 


### PR DESCRIPTION
This gem exposes no executables.