### PR TITLE
CI: Enable bundler-cache, and add rexml as a development dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle install
-      - run: rake
+          bundler-cache: true # 'bundle install' and cache gems
+      - run: bundle exec rake

--- a/xmlrpc.gemspec
+++ b/xmlrpc.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rexml"
   spec.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.