### PR TITLE
Don't unmarshal classes that don't include XMLRPC::Marshal

### DIFF
--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -113,8 +113,8 @@ module XMLRPC # :nodoc:
         begin
           mod = Module
           klass.split("::").each {|const| mod = mod.const_get(const.strip)}
+          return hash unless mod.included_modules.include?(XMLRPC::Marshallable)
 
-          return hash unless mod.included_modules.include? XMLRPC::Marshallable
           obj = mod.allocate
 
           hash.delete "___class___"

--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -114,6 +114,7 @@ module XMLRPC # :nodoc:
           mod = Module
           klass.split("::").each {|const| mod = mod.const_get(const.strip)}
 
+          return hash unless mod.included_modules.include? XMLRPC::Marshallable
           obj = mod.allocate
 
           hash.delete "___class___"

--- a/test/data/marshallable.expected
+++ b/test/data/marshallable.expected
@@ -1,0 +1,3 @@
+---
+- true
+- ___class___: Gem::Requirement

--- a/test/data/marshallable.xml
+++ b/test/data/marshallable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<methodResponse>
+  <params>
+    <param>
+      <value>
+        <struct>
+          <member>
+            <name>___class___</name>
+            <value>
+              <string>Gem::Requirement</string>
+            </value>
+          </member>
+        </struct>
+      </value>
+    </param>
+  </params>
+</methodResponse>

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -25,7 +25,10 @@ module GenericParserTest
     @datetime_xml = File.read(datafile('datetime_iso8601.xml'))
     @datetime_expected = XMLRPC::DateTime.new(2004, 11, 5, 1, 15, 23)
 
+    @marshallable_xml, @marshallable_expected = load_data('marshallable')
+
     @fault_doc = File.read(datafile('fault.xml'))
+    @marshallable = File.read(datafile('marshallable.xml'))
   end
 
   # test parseMethodResponse --------------------------------------------------
@@ -49,6 +52,11 @@ module GenericParserTest
   def test_dateTime
     assert_equal(@datetime_expected, @p.parseMethodResponse(@datetime_xml)[1])
   end
+
+  def test_marshallable
+    assert_equal(@marshallable_expected, @p.parseMethodResponse(@marshallable))
+  end
+
 
   # test parseMethodCall ------------------------------------------------------
 

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -57,7 +57,6 @@ module GenericParserTest
     assert_equal(@marshallable_expected, @p.parseMethodResponse(@marshallable))
   end
 
-
   # test parseMethodCall ------------------------------------------------------
 
   def test_parseMethodCall


### PR DESCRIPTION
If we unmarshal all classes, evil clients may run unexpected code. 

See https://hackerone.com/reports/1189419 for details.