### PR TITLE
Create accessor methods to XMLRPC::Config

### DIFF
--- a/lib/xmlrpc/client.rb
+++ b/lib/xmlrpc/client.rb
@@ -246,7 +246,7 @@ module XMLRPC # :nodoc:
     # * Date, Time, XMLRPC::DateTime
     # * XMLRPC::Base64
     # * A Ruby object which class includes XMLRPC::Marshallable
-    #   (only if Config::ENABLE_MARSHALLING is +true+).
+    #   (only if Config.enable_marshalling is +true+).
     #   That object is converted into a hash, with one additional key/value
     #   pair <code>___class___</code> which contains the class name
     #   for restoring that object later.

--- a/lib/xmlrpc/client.rb
+++ b/lib/xmlrpc/client.rb
@@ -246,7 +246,7 @@ module XMLRPC # :nodoc:
     # * Date, Time, XMLRPC::DateTime
     # * XMLRPC::Base64
     # * A Ruby object which class includes XMLRPC::Marshallable
-    #   (only if Config.enable_marshalling is +true+).
+    #   (only if Config.enable_marshalling? is +true+).
     #   That object is converted into a hash, with one additional key/value
     #   pair <code>___class___</code> which contains the class name
     #   for restoring that object later.

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -43,7 +43,9 @@ module XMLRPC # :nodoc:
       :ENABLE_MULTICALL,
       :ENABLE_INTROSPECTION
     ].each do |option|
-      define_singleton_method("#{option.downcase}") do
+      getter = option.to_s.downcase
+      getter.concat('?') if [true, false].include?(const_get(option))
+      define_singleton_method(getter) do
         const_get(option)
       end
 

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -33,14 +33,18 @@ module XMLRPC # :nodoc:
     # enable Introspection extension by default
     ENABLE_INTROSPECTION = false
 
-    def self.default_writer
-      DEFAULT_WRITER
-    end
+    [
+      :DEFAULT_WRITER
+    ].each do |option|
+      define_singleton_method("#{option.downcase}") do
+        const_get(option)
+      end
 
-    def self.default_writer=(default_writer)
-      module_eval do
-        remove_const(:DEFAULT_WRITER)
-        const_set(:DEFAULT_WRITER, default_writer)
+      define_singleton_method("#{option.downcase}=") do |value|
+        module_eval do
+          remove_const(option)
+          const_set(option, value)
+        end
       end
     end
   end

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -34,7 +34,8 @@ module XMLRPC # :nodoc:
     ENABLE_INTROSPECTION = false
 
     [
-      :DEFAULT_WRITER
+      :DEFAULT_WRITER,
+      :DEFAULT_PARSER
     ].each do |option|
       define_singleton_method("#{option.downcase}") do
         const_get(option)

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -38,7 +38,8 @@ module XMLRPC # :nodoc:
       :DEFAULT_PARSER,
       :ENABLE_NIL_CREATE,
       :ENABLE_NIL_PARSER,
-      :ENABLE_BIGINT
+      :ENABLE_BIGINT,
+      :ENABLE_MARSHALLING
     ].each do |option|
       define_singleton_method("#{option.downcase}") do
         const_get(option)

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -39,7 +39,8 @@ module XMLRPC # :nodoc:
       :ENABLE_NIL_CREATE,
       :ENABLE_NIL_PARSER,
       :ENABLE_BIGINT,
-      :ENABLE_MARSHALLING
+      :ENABLE_MARSHALLING,
+      :ENABLE_MULTICALL
     ].each do |option|
       define_singleton_method("#{option.downcase}") do
         const_get(option)

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -33,6 +33,16 @@ module XMLRPC # :nodoc:
     # enable Introspection extension by default
     ENABLE_INTROSPECTION = false
 
+    def self.default_writer
+      DEFAULT_WRITER
+    end
+
+    def self.default_writer=(default_writer)
+      module_eval do
+        remove_const(:DEFAULT_WRITER)
+        const_set(:DEFAULT_WRITER, default_writer)
+      end
+    end
   end
 
 end

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -50,10 +50,8 @@ module XMLRPC # :nodoc:
       end
 
       define_singleton_method("#{option.downcase}=") do |value|
-        module_eval do
-          remove_const(option)
-          const_set(option, value)
-        end
+        remove_const(option)
+        const_set(option, value)
       end
     end
   end

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -35,7 +35,8 @@ module XMLRPC # :nodoc:
 
     [
       :DEFAULT_WRITER,
-      :DEFAULT_PARSER
+      :DEFAULT_PARSER,
+      :ENABLE_NIL_CREATE
     ].each do |option|
       define_singleton_method("#{option.downcase}") do
         const_get(option)

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -37,7 +37,8 @@ module XMLRPC # :nodoc:
       :DEFAULT_WRITER,
       :DEFAULT_PARSER,
       :ENABLE_NIL_CREATE,
-      :ENABLE_NIL_PARSER
+      :ENABLE_NIL_PARSER,
+      :ENABLE_BIGINT
     ].each do |option|
       define_singleton_method("#{option.downcase}") do
         const_get(option)

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -40,7 +40,8 @@ module XMLRPC # :nodoc:
       :ENABLE_NIL_PARSER,
       :ENABLE_BIGINT,
       :ENABLE_MARSHALLING,
-      :ENABLE_MULTICALL
+      :ENABLE_MULTICALL,
+      :ENABLE_INTROSPECTION
     ].each do |option|
       define_singleton_method("#{option.downcase}") do
         const_get(option)

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -36,7 +36,8 @@ module XMLRPC # :nodoc:
     [
       :DEFAULT_WRITER,
       :DEFAULT_PARSER,
-      :ENABLE_NIL_CREATE
+      :ENABLE_NIL_CREATE,
+      :ENABLE_NIL_PARSER
     ].each do |option|
       define_singleton_method("#{option.downcase}") do
         const_get(option)

--- a/lib/xmlrpc/create.rb
+++ b/lib/xmlrpc/create.rb
@@ -248,7 +248,7 @@ module XMLRPC # :nodoc:
           @writer.tag("base64", param.encoded)
 
         else
-          if Config::ENABLE_MARSHALLING and param.class.included_modules.include? XMLRPC::Marshallable
+          if Config.enable_marshalling and param.class.included_modules.include? XMLRPC::Marshallable
             # convert Ruby object into Hash
             ret = {"___class___" => param.class.name}
             param.instance_variables.each {|v|

--- a/lib/xmlrpc/create.rb
+++ b/lib/xmlrpc/create.rb
@@ -199,7 +199,7 @@ module XMLRPC # :nodoc:
           @writer.tag("string", param)
 
         when NilClass
-          if Config::ENABLE_NIL_CREATE
+          if Config.enable_nil_create
             @writer.ele("nil")
           else
             raise "Wrong type NilClass. Not allowed!"
@@ -256,7 +256,7 @@ module XMLRPC # :nodoc:
               val = param.instance_variable_get(v)
 
               if val.nil?
-                ret[name] = val if Config::ENABLE_NIL_CREATE
+                ret[name] = val if Config.enable_nil_create
               else
                 ret[name] = val
               end

--- a/lib/xmlrpc/create.rb
+++ b/lib/xmlrpc/create.rb
@@ -180,7 +180,7 @@ module XMLRPC # :nodoc:
         val = case param
         when Integer
           # XML-RPC's int is 32bit int
-          if Config::ENABLE_BIGINT
+          if Config.enable_bigint
             @writer.tag("i4", param.to_s)
           else
             if param >= -(2**31) and param <= (2**31-1)

--- a/lib/xmlrpc/create.rb
+++ b/lib/xmlrpc/create.rb
@@ -180,7 +180,7 @@ module XMLRPC # :nodoc:
         val = case param
         when Integer
           # XML-RPC's int is 32bit int
-          if Config.enable_bigint
+          if Config.enable_bigint?
             @writer.tag("i4", param.to_s)
           else
             if param >= -(2**31) and param <= (2**31-1)
@@ -199,7 +199,7 @@ module XMLRPC # :nodoc:
           @writer.tag("string", param)
 
         when NilClass
-          if Config.enable_nil_create
+          if Config.enable_nil_create?
             @writer.ele("nil")
           else
             raise "Wrong type NilClass. Not allowed!"
@@ -248,7 +248,7 @@ module XMLRPC # :nodoc:
           @writer.tag("base64", param.encoded)
 
         else
-          if Config.enable_marshalling and param.class.included_modules.include? XMLRPC::Marshallable
+          if Config.enable_marshalling? and param.class.included_modules.include? XMLRPC::Marshallable
             # convert Ruby object into Hash
             ret = {"___class___" => param.class.name}
             param.instance_variables.each {|v|
@@ -256,7 +256,7 @@ module XMLRPC # :nodoc:
               val = param.instance_variable_get(v)
 
               if val.nil?
-                ret[name] = val if Config.enable_nil_create
+                ret[name] = val if Config.enable_nil_create?
               else
                 ret[name] = val
               end

--- a/lib/xmlrpc/create.rb
+++ b/lib/xmlrpc/create.rb
@@ -106,7 +106,7 @@ module XMLRPC # :nodoc:
   class Create
 
     def initialize(xml_writer = nil)
-      @writer = xml_writer || Config::DEFAULT_WRITER.new
+      @writer = xml_writer || Config.default_writer.new
     end
 
 

--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -417,7 +417,7 @@ module XMLRPC # :nodoc:
           when "struct"           then struct(child)
           when "array"            then array(child)
           when "nil"
-            if Config::ENABLE_NIL_PARSER
+            if Config.enable_nil_parser
               v_nil(child)
             else
               raise "wrong/unknown XML-RPC type 'nil'"
@@ -499,7 +499,7 @@ module XMLRPC # :nodoc:
         when "value"
           @value = nil
         when "nil"
-          raise "wrong/unknown XML-RPC type 'nil'" unless Config::ENABLE_NIL_PARSER
+          raise "wrong/unknown XML-RPC type 'nil'" unless Config.enable_nil_parser
           @value = :nil
         when "array"
           @val_stack << @values

--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -107,7 +107,7 @@ module XMLRPC # :nodoc:
     def self.struct(hash)
       # convert to marshalled object
       klass = hash["___class___"]
-      if klass.nil? or Config::ENABLE_MARSHALLING == false
+      if klass.nil? or Config.enable_marshalling == false
         hash
       else
         begin

--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -107,7 +107,7 @@ module XMLRPC # :nodoc:
     def self.struct(hash)
       # convert to marshalled object
       klass = hash["___class___"]
-      if klass.nil? or Config.enable_marshalling == false
+      if klass.nil? or Config.enable_marshalling? == false
         hash
       else
         begin
@@ -417,7 +417,7 @@ module XMLRPC # :nodoc:
           when "struct"           then struct(child)
           when "array"            then array(child)
           when "nil"
-            if Config.enable_nil_parser
+            if Config.enable_nil_parser?
               v_nil(child)
             else
               raise "wrong/unknown XML-RPC type 'nil'"
@@ -499,7 +499,7 @@ module XMLRPC # :nodoc:
         when "value"
           @value = nil
         when "nil"
-          raise "wrong/unknown XML-RPC type 'nil'" unless Config.enable_nil_parser
+          raise "wrong/unknown XML-RPC type 'nil'" unless Config.enable_nil_parser?
           @value = :nil
         when "array"
           @val_stack << @values

--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -107,7 +107,7 @@ module XMLRPC # :nodoc:
     def self.struct(hash)
       # convert to marshalled object
       klass = hash["___class___"]
-      if klass.nil? or Config.enable_marshalling? == false
+      if klass.nil? or not Config.enable_marshalling?
         hash
       else
         begin

--- a/lib/xmlrpc/server.rb
+++ b/lib/xmlrpc/server.rb
@@ -63,8 +63,8 @@ class BasicServer
     @create = nil
     @parser = nil
 
-    add_multicall     if Config.enable_multicall
-    add_introspection if Config.enable_introspection
+    add_multicall     if Config.enable_multicall?
+    add_introspection if Config.enable_introspection?
   end
 
   # Adds +aBlock+ to the list of handlers, with +name+ as the name of

--- a/lib/xmlrpc/server.rb
+++ b/lib/xmlrpc/server.rb
@@ -63,7 +63,7 @@ class BasicServer
     @create = nil
     @parser = nil
 
-    add_multicall     if Config::ENABLE_MULTICALL
+    add_multicall     if Config.enable_multicall
     add_introspection if Config::ENABLE_INTROSPECTION
   end
 

--- a/lib/xmlrpc/server.rb
+++ b/lib/xmlrpc/server.rb
@@ -64,7 +64,7 @@ class BasicServer
     @parser = nil
 
     add_multicall     if Config.enable_multicall
-    add_introspection if Config::ENABLE_INTROSPECTION
+    add_introspection if Config.enable_introspection
   end
 
   # Adds +aBlock+ to the list of handlers, with +name+ as the name of

--- a/lib/xmlrpc/utils.rb
+++ b/lib/xmlrpc/utils.rb
@@ -36,7 +36,7 @@ module XMLRPC # :nodoc:
     #
     # Should be an instance of a class from module XMLRPC::XMLParser.
     #
-    # If this method is not called, then XMLRPC::Config::DEFAULT_PARSER is used.
+    # If this method is not called, then XMLRPC::Config.default_parser is used.
     def set_parser(parser)
       @parser = parser
       self
@@ -55,7 +55,7 @@ module XMLRPC # :nodoc:
     def parser
       # if set_parser was not already called then call it now
       if @parser.nil? then
-        set_parser(Config::DEFAULT_PARSER.new)
+        set_parser(Config.default_parser.new)
       end
       @parser
     end

--- a/lib/xmlrpc/utils.rb
+++ b/lib/xmlrpc/utils.rb
@@ -26,7 +26,7 @@ module XMLRPC # :nodoc:
     #
     # Should be an instance of a class from module XMLRPC::XMLWriter.
     #
-    # If this method is not called, then XMLRPC::Config::DEFAULT_WRITER is used.
+    # If this method is not called, then XMLRPC::Config.default_writer is used.
     def set_writer(writer)
       @create = Create.new(writer)
       self
@@ -47,7 +47,7 @@ module XMLRPC # :nodoc:
     def create
       # if set_writer was not already called then call it now
       if @create.nil? then
-        set_writer(Config::DEFAULT_WRITER.new)
+        set_writer(Config.default_writer.new)
       end
       @create
     end

--- a/test/test_features.rb
+++ b/test/test_features.rb
@@ -15,19 +15,16 @@ class Test_Features < Test::Unit::TestCase
     XMLRPC::XMLWriter.each_installed_writer do |writer|
       c = XMLRPC::Create.new(writer)
 
-      XMLRPC::Config.module_eval {remove_const(:ENABLE_NIL_CREATE)}
-      XMLRPC::Config.const_set(:ENABLE_NIL_CREATE, false)
+      XMLRPC::Config.enable_nil_create = false
       assert_raise(RuntimeError) { c.methodCall("test", *@params) }
 
-      XMLRPC::Config.module_eval {remove_const(:ENABLE_NIL_CREATE)}
-      XMLRPC::Config.const_set(:ENABLE_NIL_CREATE, true)
+      XMLRPC::Config.enable_nil_create = true
       assert_nothing_raised { c.methodCall("test", *@params) }
     end
   end
 
   def test_nil_parse
-    XMLRPC::Config.module_eval {remove_const(:ENABLE_NIL_CREATE)}
-    XMLRPC::Config.const_set(:ENABLE_NIL_CREATE, true)
+    XMLRPC::Config.enable_nil_create = true
 
     XMLRPC::XMLWriter.each_installed_writer do |writer|
       c = XMLRPC::Create.new(writer)

--- a/test/test_features.rb
+++ b/test/test_features.rb
@@ -32,12 +32,10 @@ class Test_Features < Test::Unit::TestCase
       XMLRPC::XMLParser.each_installed_parser do |parser|
         para = nil
 
-        XMLRPC::Config.module_eval {remove_const(:ENABLE_NIL_PARSER)}
-        XMLRPC::Config.const_set(:ENABLE_NIL_PARSER, false)
+        XMLRPC::Config.enable_nil_parser = false
         assert_raise(RuntimeError) { para = parser.parseMethodCall(str) }
 
-        XMLRPC::Config.module_eval {remove_const(:ENABLE_NIL_PARSER)}
-        XMLRPC::Config.const_set(:ENABLE_NIL_PARSER, true)
+        XMLRPC::Config.enable_nil_parser = true
         assert_nothing_raised { para = parser.parseMethodCall(str) }
         assert_equal(para[1], @params)
       end


### PR DESCRIPTION
Currently the config is made up of a number of constants, changing the config does require some boilerplate to redefine constants. An example:
```ruby
XMLRPC::Config.module_eval { remove_const(:ENABLE_NIL_PARSER) }
XMLRPC::Config::ENABLE_NIL_PARSER = true
```

This change adds accessor methods to the Config module, so you can simply write them like this:
```ruby
XMLRPC::Config.enable_nil_parser = true
```

It still uses the constants under water, which means it is fully backwards compatible (which was the big objection in #39 )