### PR TITLE
Fix IPv6 literals in URI

### DIFF
--- a/lib/xmlrpc/client.rb
+++ b/lib/xmlrpc/client.rb
@@ -147,7 +147,7 @@ module XMLRPC # :nodoc:
       proto  = url.scheme
       user   = url.user
       passwd = url.password
-      host   = url.host
+      host   = url.hostname
       port   = url.port
       path   = url.path.empty? ? nil : url.request_uri
 


### PR DESCRIPTION
This fixes calls like this:

    XMLRPC::Client.new_from_uri('http://[::1]:8080/RPC2')

This should fix the bug I mentioned in #42.