### PR TITLE
Allow to define open and read timeout individualy

### DIFF
--- a/lib/xmlrpc/client.rb
+++ b/lib/xmlrpc/client.rb
@@ -78,7 +78,9 @@ module XMLRPC # :nodoc:
     #
     # If +use_ssl+ is set to +true+, communication over SSL is enabled.
     #
-    # Parameter +timeout+ is the time to wait for a XML-RPC response, defaults to 30.
+    # Parameter +timeout+ defines the open timeout and read timeout of the
+    # XML-RPC request. You can set them individually using the methods
+    # `open_timeout=` and `read_timeout=`
     def initialize(host=nil, path=nil, port=nil, proxy_host=nil, proxy_port=nil,
                    user=nil, password=nil, use_ssl=nil, timeout=nil)
 
@@ -213,6 +215,14 @@ module XMLRPC # :nodoc:
       @timeout = new_timeout
       @http.read_timeout = @timeout
       @http.open_timeout = @timeout
+    end
+
+    def open_timeout=(new_timeout)
+      @http.open_timeout = new_timeout
+    end
+
+    def read_timeout=(new_timeout)
+      @http.read_timeout = new_timeout
     end
 
     # Changes the user for the Basic Authentication header to +new_user+

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -77,6 +77,22 @@ module XMLRPC
       end
     end
 
+    def test_open_timeout=
+      client = Fake::Client.new 'http://example.org/foo'
+      assert_equal 30, client.http.open_timeout
+
+      client.open_timeout = 10
+      assert_equal 10, client.http.open_timeout
+    end
+
+    def test_read_timeout=
+      client = Fake::Client.new 'http://example.org/foo'
+      assert_equal 30, client.http.read_timeout
+
+      client.read_timeout = 20
+      assert_equal 20, client.http.read_timeout
+    end
+
     def test_new2_host_path_port
       client = Fake::Client.new2 'http://example.org/foo'
       host, path, port, *rest = client.args


### PR DESCRIPTION
The current implementation uses the argument `timeout` to define both open and read timeout; therefore, for a timeout of 30 seconds, the query will have a total timeout of 60 seconds. Also, it's common to want to define a lower open timeout but allow larger read timeouts.

Closes: https://github.com/ruby/xmlrpc/issues/45