### PR TITLE
Add Nokogiri XML parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group :development do
   gem "bundler"
   gem "libxml-ruby", platforms: [:ruby, :jruby]
+  gem "nokogiri"
   gem "rake"
   gem "test-unit"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem "bundler"
   gem "libxml-ruby", platforms: [:ruby, :jruby]
-  gem "nokogiri"
+  gem "nokogiri", platforms: [:ruby, :jruby]
   gem "rake"
   gem "test-unit"
 end

--- a/lib/xmlrpc.rb
+++ b/lib/xmlrpc.rb
@@ -59,6 +59,9 @@
 #   * libxml (LibXMLStreamParser)
 #     * Compiled
 #     * See https://rubygems.org/gems/libxml-ruby/
+#   * nokogiri (NokogiriStreamParser)
+#     * Compiled
+#     * See https://nokogiri.org
 #
 # * General
 #   * possible to choose between XMLParser module (Expat wrapper) and REXML (pure Ruby) parsers

--- a/lib/xmlrpc.rb
+++ b/lib/xmlrpc.rb
@@ -64,7 +64,7 @@
 #     * See https://nokogiri.org
 #
 # * General
-#   * possible to choose between XMLParser module (Expat wrapper) and REXML (pure Ruby) parsers
+#   * possible to choose between REXML (pure Ruby) and LibXML/Nokogiri (compiled) parsers
 #   * Marshalling Ruby objects to Hashes and reconstruct them later from a Hash
 #   * SandStorm component architecture XMLRPC::Client interface
 #

--- a/lib/xmlrpc/config.rb
+++ b/lib/xmlrpc/config.rb
@@ -15,6 +15,7 @@ module XMLRPC # :nodoc:
     #
     # * XMLParser::REXMLStreamParser
     # * XMLParser::LibXMLStreamParser
+    # * XMLParser::NokogiriStreamParser
     DEFAULT_PARSER = XMLParser::REXMLStreamParser
 
     # enable <code><nil/></code> tag


### PR DESCRIPTION
This one is similar to the LibXML parser, but uses the Nokogiri SAX parser under the hood. This library is already used in a lot of web projects and is easier to install in Windows than LibXML.
There is no direct dependency on the nokogiri gem, if the gem is not available the code will only error in case it is used.

Unfortunately, I could not find a way to enable the gem in the CI for the Windows tasks. It passes on the regular Windows runners, but fails on mingw/mswin, and I could not find a way to separate those two. If someone knows how to fix that, or how to install/compile Nokogiri on the latter two platforms, please go ahead and fix it.

This has been suggested/requested in https://bugs.ruby-lang.org/issues/9379, all the way back in 2014.