### PR TITLE
Remove Backport of WEBrick::Utils::TimeoutHandler.terminate from Ruby 2.4

### DIFF
--- a/test/webrick_testing.rb
+++ b/test/webrick_testing.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: false
 require 'timeout'
 
-# Backport of WEBrick::Utils::TimeoutHandler.terminate from Ruby 2.4.
-unless WEBrick::Utils::TimeoutHandler.respond_to? :terminate
-  class WEBrick::Utils::TimeoutHandler
-    def self.terminate
-      instance.terminate
-    end
-
-    def terminate
-      TimeoutMutex.synchronize{
-        @timeout_info.clear
-        @watcher&.kill&.join
-      }
-    end
-  end
-end
-
 module WEBrick_Testing
   def teardown
     WEBrick::Utils::TimeoutHandler.terminate


### PR DESCRIPTION
The tests are run on Ruby 2.5 and above, this backport is no longer required.