### PR TITLE
Update require statement for libxml_ruby 6.0.0

### DIFF
--- a/lib/xmlrpc/parser.rb
+++ b/lib/xmlrpc/parser.rb
@@ -595,7 +595,7 @@ module XMLRPC # :nodoc:
 
     class LibXMLStreamParser < AbstractStreamParser
       def initialize
-        require 'libxml'
+        require 'libxml-ruby'
         @parser_class = LibXMLStreamListener
       end
 


### PR DESCRIPTION
Requiring libxml no longer works, but `libxml-ruby` does work on older versions too.

Tested it locally with `bundle exec rake test XMLRPC_PARSER=libxml` with libxml-ruby 6.0.0 and 5.0.6, I'm not sure if the CI includes this.