### PR TITLE
Update Ruby versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
           - macos
           - windows
         ruby:
-          - "2.5"
           - "2.6"
           - "2.7"
           - "3.0"
@@ -30,7 +29,6 @@ jobs:
           - { os: windows , ruby: mingw }
           - { os: windows , ruby: mswin }
         exclude:
-          - { os: macos   , ruby: "2.5" }
           - { os: windows , ruby: head }
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
           - head
         include:
           - { os: windows , ruby: mingw }


### PR DESCRIPTION
* Remove Ruby 2.5, this one is broken outside of the control of the gem (see https://github.com/ruby/xmlrpc/pull/63#issuecomment-4212012925)
* Add missing Ruby 4.0